### PR TITLE
Replace hard-coded strings with placeholders when adding a command

### DIFF
--- a/octoprint_TerminalCommands/static/js/TerminalCommands.js
+++ b/octoprint_TerminalCommands/static/js/TerminalCommands.js
@@ -16,7 +16,7 @@ $(function() {
         self.addTerminalCommand = function(data) {
             console.log("addTerminalCommand: ")
             console.log(data);
-            self.terminalCommands.push({name: "Name", commands: "Commands"})
+            self.terminalCommands.push({name: "", commands: ""})
         };
 
         self.removeTerminalCommand = function(filter) {
@@ -83,7 +83,7 @@ $(function() {
             // copy and reverse array so buttons appear in the order they're added (!)
             self.terminalCommands().slice(0).reverse().forEach(function(data) {
                 var name, commands;
-                
+
                 if(typeof data.name === 'function') {
                     name = data.name();
                     commands = data.commands();
@@ -97,7 +97,7 @@ $(function() {
                     <button type=\"button\" class=\"btn termctrl\">" + name + "</button>\
                 ");
             });
-                            
+
             $("button.termctrl").click(function() {
                 var button = $(this);
                 var command = getCmdFromName(button.text());

--- a/octoprint_TerminalCommands/templates/TerminalCommands_settings.jinja2
+++ b/octoprint_TerminalCommands/templates/TerminalCommands_settings.jinja2
@@ -7,10 +7,10 @@
     <div data-bind="foreach: terminalCommands">
         <div class="row-fluid" style="margin-bottom: 5px">
             <div class="span4">
-                <input type="text" class="span12" data-bind="value: name">
+                <input type="text" class="span12" data-bind="value: name" placeholder="Name">
             </div>
             <div class="span6">
-                <input type="text" class="span12" data-bind="value: commands">
+                <input type="text" class="span12" data-bind="value: commands" placeholder="Commands">
             </div>
             <div class="span2">
                 <a title="Remove Command" class="btn btn-danger" data-bind="click: $root.removeTerminalCommand"><i class="fa fa-trash-o"></i></a>


### PR DESCRIPTION
I found it annoying to have to erase the current hard-coded placeholders when adding a command, so I modified the code to use actual placeholders instead.