### PR TITLE
Fixes issues #14, #17, #18 : Python 3 Compatibility

### DIFF
--- a/octoprint_TerminalCommands/__init__.py
+++ b/octoprint_TerminalCommands/__init__.py
@@ -39,6 +39,7 @@ class TerminalCommandsPlugin(octoprint.plugin.SettingsPlugin,
 		)
 
 __plugin_name__ = "Terminal Commands"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__


### PR DESCRIPTION
The plugin works with Python 3 already, it just needs to advertise it.

For those who don't want to wait for this pull request to be merged, you can install this updated version manually from this URL:
```
https://github.com/combolek/OctoPrint-TerminalCommands/archive/refs/heads/python3.zip
```
(use "Install from URL" in the OctoPrint Plugin Manager).

Alternatively, you can install from the original URL and make the one line change yourself in `__init__.py`.
